### PR TITLE
Short-circuit `paddedviews(fillvalue)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@
 
 ## Summary
 
-PaddedViews provides a simple wrapper type, `PaddedView` to add
+PaddedViews provides a simple wrapper type, `PaddedView`, to add
 "virtual" padding to any array without copying data. Edge values not
 specified by the array are assigned a `fillvalue`.  Multiple arrays
 may be "promoted" to have common indices using the `paddedviews`
 function.
+
+`PaddedView` arrays are read-only, meaning that you cannot assign
+values to them. The original array may be extracted using `A =
+parent(P)`, where `P` is a `PaddedView`.
 
 ## Examples
 

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -101,6 +101,7 @@ function paddedviews(fillvalue, As::AbstractArray...)
     inds = outerinds(As...)
     map(A->PaddedView(fillvalue, A, inds), As)
 end
+paddedviews(fillvalue) = nothing
 
 @inline outerinds(A::AbstractArray, Bs...) = _outerinds(indices(A), Bs...)
 @inline _outerinds(inds, A::AbstractArray, Bs...) =

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -112,6 +112,11 @@ _outerinds(inds) = inds
 _outerinds{N}(inds1::NTuple{N,AbstractUnitRange}, inds2::NTuple{N,AbstractUnitRange}) =
     map((i1, i2) -> convert(UnitRange{Int}, padrange(i1, i2)), inds1, inds2)
 
+# This shouldn't be reached due to the `paddedviews(fillvalue)` method above,
+# but it's here in case anyone extends `paddedviews` for types other than AbstractArrays.
+# See https://github.com/JuliaImages/ImageCore.jl/pull/32#discussion_r111545756
+outerinds() = error("must supply at least one array with concrete indices")
+
 padrange(i1::OneTo, i2::OneTo) = OneTo(max(last(i1), last(i2)))
 padrange(i1::AbstractUnitRange, i2::AbstractUnitRange) = min(first(i1),first(i2)):max(last(i1), last(i2))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,62 +2,69 @@ using OffsetArrays
 using Base.Test
 ambs = detect_ambiguities(Base, Core)  # in case these have ambiguities of their own
 using PaddedViews
-@test isempty(setdiff(detect_ambiguities(PaddedViews, Base, Core), ambs))
-
-# Basics
-for n = 0:5
-    a = @inferred(PaddedView(0, ones(Int,ntuple(d->1,n)), ntuple(x->x+1,n)))
-    @test indices(a) == ntuple(x->1:x+1,n)
-    @test @inferred(a[1]) == 1
-    n > 0 && @test @inferred(a[2]) == 0
-    @test @inferred(a[ntuple(x->1,n)...]) == 1
-    n > 0 && @test @inferred(a[2, ntuple(x->1,n-1)...]) == 0
+@testset "ambiguities" begin
+    @test isempty(setdiff(detect_ambiguities(PaddedViews, Base, Core), ambs))
 end
-a0 = reshape([3])
-a = @inferred(PaddedView(-1, a0, ()))
-@test indices(a) == ()
-@test ndims(a) == 0
-@test a[] == 3
 
-a = reshape(1:9, 3, 3)
-A = @inferred(PaddedViews.PaddedView(0.0, a, (Base.OneTo(4), Base.OneTo(5))))
-@test eltype(A) == Int
-@test ndims(A) == 2
-@test size(A) === (4,5)
-@test @inferred(indices(A)) === (Base.OneTo(4), Base.OneTo(5))
-@test @inferred(indices(A, 3)) === Base.OneTo(1)
-@test A == [1 4 7 0 0;
-            2 5 8 0 0;
-            3 6 9 0 0;
-            0 0 0 0 0]
+@testset "PaddedView" begin
+    for n = 0:5
+        a = @inferred(PaddedView(0, ones(Int,ntuple(d->1,n)), ntuple(x->x+1,n)))
+        @test indices(a) == ntuple(x->1:x+1,n)
+        @test @inferred(a[1]) == 1
+        n > 0 && @test @inferred(a[2]) == 0
+        @test @inferred(a[ntuple(x->1,n)...]) == 1
+        n > 0 && @test @inferred(a[2, ntuple(x->1,n-1)...]) == 0
+    end
+    a0 = reshape([3])
+    a = @inferred(PaddedView(-1, a0, ()))
+    @test indices(a) == ()
+    @test ndims(a) == 0
+    @test a[] == 3
 
-A = @inferred(PaddedViews.PaddedView(0.0, a, (0:4, -1:5)))
-@test eltype(A) == Int
-@test ndims(A) == 2
-@test_throws ErrorException size(A)
-@test @inferred(indices(A)) === (0:4, -1:5)
-@test @inferred(indices(A, 3)) === 1:1
-@test A == OffsetArray([0 0 0 0 0 0 0;
-                        0 0 1 4 7 0 0;
-                        0 0 2 5 8 0 0;
-                        0 0 3 6 9 0 0;
-                        0 0 0 0 0 0 0], 0:4, -1:5)
+    a = reshape(1:9, 3, 3)
+    A = @inferred(PaddedView(0.0, a, (Base.OneTo(4), Base.OneTo(5))))
+    @test eltype(A) == Int
+    @test ndims(A) == 2
+    @test size(A) === (4,5)
+    @test @inferred(indices(A)) === (Base.OneTo(4), Base.OneTo(5))
+    @test @inferred(indices(A, 3)) === Base.OneTo(1)
+    @test A == [1 4 7 0 0;
+                2 5 8 0 0;
+                3 6 9 0 0;
+                0 0 0 0 0]
 
-a1 = reshape([1,2], 2, 1)
-a2 = [1.0,2.0]'
-a1p, a2p = @inferred(paddedviews(0, a1, a2))
-@test a1p == [1 0; 2 0]
-@test a2p == [1.0 2.0; 0.0 0.0]
-@test eltype(a1p) == Int
-@test eltype(a2p) == Float64
-@test indices(a1p) === indices(a2p) === (Base.OneTo(2), Base.OneTo(2))
+    A = @inferred(PaddedView(0.0, a, (0:4, -1:5)))
+    @test eltype(A) == Int
+    @test ndims(A) == 2
+    @test_throws ErrorException size(A)
+    @test @inferred(indices(A)) === (0:4, -1:5)
+    @test @inferred(indices(A, 3)) === 1:1
+    @test A == OffsetArray([0 0 0 0 0 0 0;
+                            0 0 1 4 7 0 0;
+                            0 0 2 5 8 0 0;
+                            0 0 3 6 9 0 0;
+                            0 0 0 0 0 0 0], 0:4, -1:5)
+end
 
-a3 = OffsetArray([1.0,2.0]', (0,-1))
-a1p, a3p = @inferred(paddedviews(0, a1, a3))
-@test a1p == OffsetArray([0 1; 0 2], 1:2, 0:1)
-@test a3p == OffsetArray([1.0 2.0; 0.0 0.0], 1:2, 0:1)
-@test eltype(a1p) == Int
-@test eltype(a3p) == Float64
-@test indices(a1p) === indices(a3p) === (1:2, 0:1)
+@testset "paddedviews" begin
+    a1 = reshape([1,2], 2, 1)
+    a2 = [1.0,2.0]'
+    a1p, a2p = @inferred(paddedviews(0, a1, a2))
+    @test a1p == [1 0; 2 0]
+    @test a2p == [1.0 2.0; 0.0 0.0]
+    @test eltype(a1p) == Int
+    @test eltype(a2p) == Float64
+    @test indices(a1p) === indices(a2p) === (Base.OneTo(2), Base.OneTo(2))
+
+    a3 = OffsetArray([1.0,2.0]', (0,-1))
+    a1p, a3p = @inferred(paddedviews(0, a1, a3))
+    @test a1p == OffsetArray([0 1; 0 2], 1:2, 0:1)
+    @test a3p == OffsetArray([1.0 2.0; 0.0 0.0], 1:2, 0:1)
+    @test eltype(a1p) == Int
+    @test eltype(a3p) == Float64
+    @test indices(a1p) === indices(a3p) === (1:2, 0:1)
+
+    @test @inferred(paddedviews(3)) == nothing
+end
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,10 @@ end
     @test indices(a1p) === indices(a3p) === (1:2, 0:1)
 
     @test @inferred(paddedviews(3)) == nothing
+    @test_throws ErrorException PaddedViews.outerinds()
+    # But a zero-dimensional input should not trigger that error
+    a = reshape([5])
+    @test paddedviews(-1, a) == (a,)
 end
 
 nothing


### PR DESCRIPTION
Addresses the issue noticed in https://github.com/JuliaImages/ImageCore.jl/pull/32#discussion_r111545756.