### PR TITLE
nothing->() in paddedviews(fillvalue)

### DIFF
--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -101,7 +101,7 @@ function paddedviews(fillvalue, As::AbstractArray...)
     inds = outerinds(As...)
     map(A->PaddedView(fillvalue, A, inds), As)
 end
-paddedviews(fillvalue) = nothing
+paddedviews(fillvalue) = ()
 
 @inline outerinds(A::AbstractArray, Bs...) = _outerinds(indices(A), Bs...)
 @inline _outerinds(inds, A::AbstractArray, Bs...) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,7 +64,7 @@ end
     @test eltype(a3p) == Float64
     @test indices(a1p) === indices(a3p) === (1:2, 0:1)
 
-    @test @inferred(paddedviews(3)) == nothing
+    @test @inferred(paddedviews(3)) == ()
     @test_throws ErrorException PaddedViews.outerinds()
     # But a zero-dimensional input should not trigger that error
     a = reshape([5])


### PR DESCRIPTION
This is more consistent with `paddedviews(fillvalues, As...)`.