### PR TITLE
Add support for padding around an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ julia> PaddedView(-1, a, (4, 5))   # -1 is the fill value, (4, 5) is the desired
   2   5   8  -1  -1
   3   6   9  -1  -1
  -1  -1  -1  -1  -1
+
+julia> PaddedView(-1, a, (4,5), (2,2)) # (2, 2) is the location of the first element from a
+4×5 PaddedViews.PaddedView{Int64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}},OffsetArrays.OffsetArray{Int64,2,Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}}}:
+ -1  -1  -1  -1  -1
+ -1   1   4   7  -1
+ -1   2   5   8  -1
+ -1   3   6   9  -1
 ```
 
 For padding multiple arrays to have common indices:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+OffsetArrays

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,14 @@ end
                             0 0 2 5 8 0 0;
                             0 0 3 6 9 0 0;
                             0 0 0 0 0 0 0], 0:4, -1:5)
+    
+    A = @inferred(PaddedView(0.0, a, (Base.OneTo(5), Base.OneTo(5)), (2:4, 2:4)))
+    @test A == [0 0 0 0 0;
+                0 1 4 7 0;
+                0 2 5 8 0;
+                0 3 6 9 0;
+                0 0 0 0 0]
+    @test A == @inferred(PaddedView(0.0, a, (5, 5), (2, 2)))
 end
 
 @testset "paddedviews" begin


### PR DESCRIPTION
To address #9. I should add that the order of the arguments here has been tweaked slightly (compared with #9) to be more consistent with the existing methods.