### PR TITLE
Allow creation of `PaddedView`s that shrink

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -15,19 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"PaddedViews\"); Pkg.build(\"PaddedViews\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"PaddedViews\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -85,7 +85,7 @@ function PaddedView(fillvalue,
                     data::AbstractArray{T,N},
                     padded_inds::NTuple{N,AbstractUnitRange},
                     data_inds::NTuple{N,AbstractUnitRange}) where {T,N}
-    @assert all(map(last, data_inds) .<= map(last, padded_inds)) "incompatible axes for embedded array $data_inds and padded view $padded_inds"
+
     off_data = OffsetArray(data, data_inds...)
     return PaddedView(fillvalue, off_data, padded_inds)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,30 +55,30 @@ end
 
     @test PaddedView(0, ones(4), (3,), (1,)) == PaddedView(0, ones(4), (3,))
     let a = reshape(1:6, 2, 3) # [1 3 5; 2 4 6]
-        @test PaddedView(-1, a, (2, 2))          == [1 3
-                                                     2 4]
+        @test @inferred(PaddedView(-1, a, (2, 2))) == [1 3
+                                                       2 4]
 
-        @test PaddedView(-1, a, (1, 4))          == [1 3 5 -1 ]
+        @test @inferred(PaddedView(-1, a, (1, 4)))  == [1 3 5 -1 ]
 
-        @test PaddedView(-1, a, (2, 4), (1, 1))  == [1 3 5 -1
-                                                     2 4 6 -1]
+        @test @inferred(PaddedView(-1, a, (2, 4), (1, 1)))  == [1 3 5 -1
+                                                                2 4 6 -1]
 
-        @test PaddedView(-1, a, (2, 4), (1, 2))  == [-1 1 3 5
-                                                     -1 2 4 6]
+        @test @inferred(PaddedView(-1, a, (2, 4), (1, 2)))  == [-1 1 3 5
+                                                                -1 2 4 6]
 
-        @test PaddedView(-1, a, (2, 3), (0, 2))  == [-1  2  4
-                                                     -1 -1 -1]                                                      
+        @test @inferred(PaddedView(-1, a, (2, 3), (0, 2)))  == [-1  2  4
+                                                                -1 -1 -1]                                                      
 
-        @test PaddedView(-1, a, (1, 4), (1, -1)) == [5 -1 -1 -1]
+        @test @inferred(PaddedView(-1, a, (1, 4), (1, -1))) == [5 -1 -1 -1]
               
         # Create an OffsetArray with axes (0:1, 2:4)
         oa = OffsetArray(a, -1, 1)
         # Make a PaddedView of its elements (1:3, 1:2) (i.e pv[1, 1] == oa[1, 1] == "a[2, 0]" == -1)
-        pv = PaddedView(-1, oa, (3, 2))
+        pv = @inferred PaddedView(-1, oa, (3, 2))
         @test pv[1:3, 1:2] == [-1 2; -1 -1; -1 -1]
         # Put oa[1, 1] in pv[2, 0] and make a PaddedView of the resulting (1:3, 1:2) elements
             # i.e. same as putting oa[0,2] in pv[1, 1]
-        pv = PaddedView(-1, oa, (3, 2), (2, 0))
+        pv = @inferred PaddedView(-1, oa, (3, 2), (2, 0))
         @test pv[1:3, 1:2] == [1 3; 2 4; -1 -1] 
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,24 @@ end
     @test A == @inferred(PaddedView(0.0, a, (5, 5), (2, 2)))
 
     @test PaddedView(0, ones(4), (3,), (1,)) == PaddedView(0, ones(4), (3,))
+    let a = reshape(1:6, 2, 3) # [1 3 5; 2 4 6]
+        @test PaddedView(-1, a, (2, 2))          == [1 3
+                                                     2 4]
+
+        @test PaddedView(-1, a, (1, 4))          == [1 3 5 -1 ]
+
+        @test PaddedView(-1, a, (2, 4), (1, 1))  == [1 3 5 -1
+                                                     2 4 6 -1]
+
+        @test PaddedView(-1, a, (2, 4), (1, 2))  == [-1 1 3 5
+                                                     -1 2 4 6]
+
+        @test PaddedView(-1, a, (2, 3), (0, 2))  == [-1  2  4
+                                                     -1 -1 -1]                                                      
+
+        @test PaddedView(-1, a, (1, 4), (1, -1)) == [5 -1 -1 -1]
+                                                      
+        end
 end
 
 @testset "paddedviews" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,8 +70,17 @@ end
                                                      -1 -1 -1]                                                      
 
         @test PaddedView(-1, a, (1, 4), (1, -1)) == [5 -1 -1 -1]
-                                                      
-        end
+              
+        # Create an OffsetArray with axes (0:1, 2:4)
+        oa = OffsetArray(a, -1, 1)
+        # Make a PaddedView of its elements (1:3, 1:2) (i.e pv[1, 1] == oa[1, 1] == "a[2, 0]" == -1)
+        pv = PaddedView(-1, oa, (3, 2))
+        @test pv[1:3, 1:2] == [-1 2; -1 -1; -1 -1]
+        # Put oa[1, 1] in pv[2, 0] and make a PaddedView of the resulting (1:3, 1:2) elements
+            # i.e. same as putting oa[0,2] in pv[1, 1]
+        pv = PaddedView(-1, oa, (3, 2), (2, 0))
+        @test pv[1:3, 1:2] == [1 3; 2 4; -1 -1] 
+    end
 end
 
 @testset "paddedviews" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,8 @@ end
                 0 3 6 9 0;
                 0 0 0 0 0]
     @test A == @inferred(PaddedView(0.0, a, (5, 5), (2, 2)))
+
+    @test PaddedView(0, ones(4), (3,), (1,)) == PaddedView(0, ones(4), (3,))
 end
 
 @testset "paddedviews" begin


### PR DESCRIPTION
`PaddedView(0, ones(4), (3,))` shrinks it to `[1.0, 1.0, 1.0]`.

However, attempting to explicitly pass the index as `PaddedView(0, ones(4), (3,), (1,))` fails. This works fine in the common case where the size is increased.

It seems to me there's an `@assert` that prevents the indices from not containing the full embedded array's axes. However, one actually is allowed to construct a `PaddedView` with these characteristics through other methods. I don't think there's any need to prevent the embedded array to exceed the bounds of `indices`.