### PR TITLE
add sym_paddedviews: a centered version for paddedviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ julia> a2 = [4 5 6]
 1×3 Array{Int64,2}:
  4  5  6
 
-julia> a1p, a2p = cpaddedviews(-1, a1, a2);
+julia> a1p, a2p = sym_paddedviews(-1, a1, a2);
 
 julia> a1p
 3×3 PaddedView(-1, ::Array{Int64,2}, (1:3, 0:2)) with eltype Int64 with indices 1:3×0:2:

--- a/README.md
+++ b/README.md
@@ -67,24 +67,55 @@ julia> PaddedView(-1, a, (5,5), (2,2))
 For padding multiple arrays to have common indices:
 
 ```julia
-julia> a1 = reshape([1,2], 2, 1)
-2×1 Array{Int64,2}:
+julia> a1 = reshape([1, 2, 3], 3, 1)
+3×1 Array{Int64,2}:
  1
  2
+ 3
 
-julia> a2 = [1.0,2.0]'
-1×2 LinearAlgebra.Adjoint{Float64,Array{Float64,1}}:
- 1.0  2.0
+julia> a2 = [4 5 6]
+1×3 Array{Int64,2}:
+ 4  5  6
 
-julia> a1p, a2p = paddedviews(0, a1, a2);   # 0 is the fill value
+julia> a1p, a2p = paddedviews(-1, a1, a2);
 
 julia> a1p
-2×2 PaddedView(0, ::Array{Int64,2}, (Base.OneTo(2), Base.OneTo(2))) with eltype Int64:
- 1  0
- 2  0
+3×3 PaddedView(-1, ::Array{Int64,2}, (Base.OneTo(3), Base.OneTo(3))) with eltype Int64:
+ 1  -1  -1
+ 2  -1  -1
+ 3  -1  -1
 
 julia> a2p
-2×2 PaddedView(0.0, ::LinearAlgebra.Adjoint{Float64,Array{Float64,1}}, (Base.OneTo(2), Base.OneTo(2))) with eltype Float64:
- 1.0  2.0
- 0.0  0.0
+3×3 PaddedView(-1, ::Array{Int64,2}, (Base.OneTo(3), Base.OneTo(3))) with eltype Int64:
+  4   5   6
+ -1  -1  -1
+ -1  -1  -1
+```
+
+If you want original arrays in the center of padded results:
+
+```julia
+julia> a1 = reshape([1, 2, 3], 3, 1)
+3×1 Array{Int64,2}:
+ 1
+ 2
+ 3
+
+julia> a2 = [4 5 6]
+1×3 Array{Int64,2}:
+ 4  5  6
+
+julia> a1p, a2p = cpaddedviews(-1, a1, a2);
+
+julia> a1p
+3×3 PaddedView(-1, ::Array{Int64,2}, (1:3, 0:2)) with eltype Int64 with indices 1:3×0:2:
+ -1  1  -1
+ -1  2  -1
+ -1  3  -1
+
+julia> a2p
+3×3 PaddedView(-1, ::Array{Int64,2}, (0:2, 1:3)) with eltype Int64 with indices 0:2×1:3:
+ -1  -1  -1
+  4   5   6
+ -1  -1  -1
 ```

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -2,7 +2,7 @@ module PaddedViews
 using Base: OneTo, tail
 using OffsetArrays
 
-export PaddedView, paddedviews, cpaddedviews
+export PaddedView, paddedviews, sym_paddedviews
 
 """
     datapadded = PaddedView(fillvalue, data, padded_axes)
@@ -140,7 +140,7 @@ Pad the arrays `A1`, `A2`, ..., to a common size or set of axes,
 chosen as the span of axes enclosing all of the input arrays.
 
 The padding is applied to one direction. For example, values are filled to bottom-right part
-of the new array in two-dimensional case. Use [`cpaddedviews`](@ref) if _both_ directions
+of the new array in two-dimensional case. Use [`sym_paddedviews`](@ref) if _both_ directions
 need to be padded.
 
 The axes of original array `A` will be preserved in the padded result `Ap`, hence it's true
@@ -204,7 +204,7 @@ padrange(i1::AbstractUnitRange, i2::AbstractUnitRange) = min(first(i1),first(i2)
 
 
 """
-    Aspad = cpaddedviews(fillvalue, A1, A2, ....)
+    Aspad = sym_paddedviews(fillvalue, A1, A2, ....)
 
 Pad the arrays `A1`, `A2`, ..., to a common size or set of axes, chosen as the span of axes
 enclosing all of the input arrays.
@@ -226,7 +226,7 @@ julia> a2 = [4 5 6]
 1×3 Array{Int64,2}:
  4  5  6
 
-julia> a1p, a2p = cpaddedviews(-1, a1, a2);
+julia> a1p, a2p = sym_paddedviews(-1, a1, a2);
 
 julia> a1p
 3×3 PaddedView(-1, ::Array{Int64,2}, (1:3, 0:2)) with eltype Int64 with indices 1:3×0:2:
@@ -247,13 +247,13 @@ julia> a1p[CartesianIndices(a1)]
  3
  ```
 """
-function cpaddedviews(fillvalue, As::AbstractArray...)
+function sym_paddedviews(fillvalue, As::AbstractArray...)
     inds = outerinds(As...)
-    map((A, A_axes)->PaddedView(fillvalue, A, _cpad_inds(A_axes, inds)), As, axes.(As))
+    map((A, A_axes)->PaddedView(fillvalue, A, _sym_pad_inds(A_axes, inds)), As, axes.(As))
 end
-cpaddedviews(fillvalue) = ()
+sym_paddedviews(fillvalue) = ()
 
-function _cpad_inds(A_axes, inds)
+function _sym_pad_inds(A_axes, inds)
     map(A_axes, inds) do ax, i
         pad_sz = length(i) - length(ax)
         offset = pad_sz ÷ 2

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -2,7 +2,7 @@ module PaddedViews
 using Base: OneTo, tail
 using OffsetArrays
 
-export PaddedView, paddedviews
+export PaddedView, paddedviews, cpaddedviews
 
 """
     datapadded = PaddedView(fillvalue, data, padded_axes)
@@ -139,28 +139,44 @@ end
 Pad the arrays `A1`, `A2`, ..., to a common size or set of axes,
 chosen as the span of axes enclosing all of the input arrays.
 
+The padding is applied to one direction. For example, values are filled to bottom-right part
+of the new array in two-dimensional case. Use [`cpaddedviews`](@ref) if _both_ directions
+need to be padded.
+
+The axes of each array `A` will be perserved in the padded result `Ap`, which means
+`Ap[CartesianIndices(A)] == A` holds true.
+
 # Example:
-```julia
-julia> a1 = reshape([1,2], 2, 1)
-2×1 Array{Int64,2}:
+```jldoctest
+julia> a1 = reshape([1, 2, 3], 3, 1)
+3×1 Array{Int64,2}:
  1
  2
+ 3
 
-julia> a2 = [1.0,2.0]'
-1×2 Array{Float64,2}:
- 1.0  2.0
+julia> a2 = [4 5 6]
+1×3 Array{Int64,2}:
+ 4  5  6
 
-julia> a1p, a2p = paddedviews(0, a1, a2);
+julia> a1p, a2p = paddedviews(-1, a1, a2);
 
 julia> a1p
-2×2 PaddedViews.PaddedView{Int64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}},Array{Int64,2}}:
- 1  0
- 2  0
+3×3 PaddedView(-1, ::Array{Int64,2}, (Base.OneTo(3), Base.OneTo(3))) with eltype Int64:
+ 1  -1  -1
+ 2  -1  -1
+ 3  -1  -1
 
 julia> a2p
-2×2 PaddedViews.PaddedView{Float64,2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}},Array{Float64,2}}:
- 1.0  2.0
- 0.0  0.0
+3×3 PaddedView(-1, ::Array{Int64,2}, (Base.OneTo(3), Base.OneTo(3))) with eltype Int64:
+  4   5   6
+ -1  -1  -1
+ -1  -1  -1
+
+julia> a1p[CartesianIndices(a1)]
+3×1 Array{Int64,2}:
+ 1
+ 2
+ 3
 ```
 """
 function paddedviews(fillvalue, As::AbstractArray...)
@@ -185,6 +201,69 @@ outerinds() = error("must supply at least one array with concrete axes")
 
 padrange(i1::OneTo, i2::OneTo) = OneTo(max(last(i1), last(i2)))
 padrange(i1::AbstractUnitRange, i2::AbstractUnitRange) = min(first(i1),first(i2)):max(last(i1), last(i2))
+
+
+"""
+    Aspad = cpaddedviews(fillvalue, A1, A2, ....)
+
+Pad the arrays `A1`, `A2`, ..., to a common size or set of axes, chosen as the span of axes
+enclosing all of the input arrays.
+
+The padding is applied to both directions, which means original array located at the center
+the padded result. Use [`paddedviews`](@ref) if only one direction need to be padded.
+
+The axes of each array `A` will be perserved in the padded result `Ap`, which means
+`Ap[CartesianIndices(A)] == A` holds true.
+
+
+```jldoctest
+julia> a1 = reshape([1, 2, 3], 3, 1)
+3×1 Array{Int64,2}:
+ 1
+ 2
+ 3
+
+julia> a2 = [4 5 6]
+1×3 Array{Int64,2}:
+ 4  5  6
+
+julia> a1p, a2p = cpaddedviews(-1, a1, a2);
+
+julia> a1p
+3×3 PaddedView(-1, ::Array{Int64,2}, (1:3, 0:2)) with eltype Int64 with indices 1:3×0:2:
+ -1  1  -1
+ -1  2  -1
+ -1  3  -1
+
+julia> a2p
+3×3 PaddedView(-1, ::Array{Int64,2}, (0:2, 1:3)) with eltype Int64 with indices 0:2×1:3:
+ -1  -1  -1
+  4   5   6
+ -1  -1  -1
+
+julia> a1p[CartesianIndices(a1)]
+3×1 Array{Int64,2}:
+ 1
+ 2
+ 3
+ ```
+"""
+function cpaddedviews(fillvalue, As::AbstractArray...)
+    N = ndims(As[1])
+    # ~10x than paddedviews :disappointed:
+    out_sz = tuple(mapreduce(size, (x,y)->maximum.(zip(x, y)), As)...)::NTuple{N}
+    map(A->PaddedView(fillvalue, A, _cpad_offset(A, out_sz)), As)
+end
+cpaddedviews(fillvalue) = ()
+
+function _cpad_offset(A::AbstractArray, sz)
+    map(axes(A), sz) do ax, l
+        pad_sz = l - length(ax)
+        offset = pad_sz ÷ 2
+        first(ax)-offset:last(ax)+pad_sz-offset
+    end
+end
+
 
 function Base.showarg(io::IO, A::PaddedView, toplevel)
     print(io, "PaddedView(", A.fillvalue, ", ")

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -249,14 +249,14 @@ julia> a1p[CartesianIndices(a1)]
  ```
 """
 function cpaddedviews(fillvalue, As::AbstractArray...)
-    N = ndims(As[1])
-    # ~10x than paddedviews :disappointed:
-    out_sz = tuple(mapreduce(size, (x,y)->maximum.(zip(x, y)), As)...)::NTuple{N}
-    map(A->PaddedView(fillvalue, A, _cpad_offset(A, out_sz)), As)
+    out_sz = length.(outerinds(As...))
+    map(A->PaddedView(fillvalue, A, _cpad_inds(A, out_sz)), As)
 end
 cpaddedviews(fillvalue) = ()
 
-function _cpad_offset(A::AbstractArray, sz)
+
+
+function _cpad_inds(A::AbstractArray, sz)
     map(axes(A), sz) do ax, l
         pad_sz = l - length(ax)
         offset = pad_sz ÷ 2

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -249,16 +249,14 @@ julia> a1p[CartesianIndices(a1)]
  ```
 """
 function cpaddedviews(fillvalue, As::AbstractArray...)
-    out_sz = length.(outerinds(As...))
-    map(A->PaddedView(fillvalue, A, _cpad_inds(A, out_sz)), As)
+    inds = outerinds(As...)
+    map((A, A_axes)->PaddedView(fillvalue, A, _cpad_inds(A_axes, inds)), As, axes.(As))
 end
 cpaddedviews(fillvalue) = ()
 
-
-
-function _cpad_inds(A::AbstractArray, sz)
-    map(axes(A), sz) do ax, l
-        pad_sz = l - length(ax)
+function _cpad_inds(A_axes, inds)
+    map(A_axes, inds) do ax, i
+        pad_sz = length(i) - length(ax)
         offset = pad_sz ÷ 2
         first(ax)-offset:last(ax)+pad_sz-offset
     end

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -143,8 +143,8 @@ The padding is applied to one direction. For example, values are filled to botto
 of the new array in two-dimensional case. Use [`cpaddedviews`](@ref) if _both_ directions
 need to be padded.
 
-The axes of each array `A` will be perserved in the padded result `Ap`, which means
-`Ap[CartesianIndices(A)] == A` holds true.
+The axes of original array `A` will be preserved in the padded result `Ap`, hence it's true
+that `Ap[CartesianIndices(A)] == A`.
 
 # Example:
 ```jldoctest
@@ -212,9 +212,8 @@ enclosing all of the input arrays.
 The padding is applied to both directions, which means original array located at the center
 the padded result. Use [`paddedviews`](@ref) if only one direction need to be padded.
 
-The axes of each array `A` will be perserved in the padded result `Ap`, which means
-`Ap[CartesianIndices(A)] == A` holds true.
-
+The axes of original array `A` will be preserved in the padded result `Ap`, hence it's true
+that `Ap[CartesianIndices(A)] == A`.
 
 ```jldoctest
 julia> a1 = reshape([1, 2, 3], 3, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,6 +117,18 @@ end
 end
 
 @testset "cpaddedviews" begin
+    # even case
+    a1 = reshape([1,2], 2, 1)
+    a2 = [1.0,2.0]'
+    a1p, a2p = @inferred(cpaddedviews(0, a1, a2))
+    @test a1p == [1 0; 2 0]
+    @test a1p[CartesianIndices(a1)] == a1
+    @test a2p == [1.0 2.0; 0.0 0.0]
+    @test a2p[CartesianIndices(a2)] == a2
+    @test eltype(a1p) == Int
+    @test eltype(a2p) == Float64
+    @test axes(a1p) === axes(a2p) === (1:2, 1:2)
+
     a1 = reshape([1,2,3], 3, 1)
     a2 = [1.0,2.0,3.0]'
     a1p, a2p = @inferred(cpaddedviews(0, a1, a2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,11 +116,11 @@ end
     @test paddedviews(-1, a) == (a,)
 end
 
-@testset "cpaddedviews" begin
+@testset "sym_paddedviews" begin
     # even case
     a1 = reshape([1,2], 2, 1)
     a2 = [1.0,2.0]'
-    a1p, a2p = @inferred(cpaddedviews(0, a1, a2))
+    a1p, a2p = @inferred(sym_paddedviews(0, a1, a2))
     @test a1p == [1 0; 2 0]
     @test a1p[CartesianIndices(a1)] == a1
     @test a2p == [1.0 2.0; 0.0 0.0]
@@ -131,7 +131,7 @@ end
 
     a1 = reshape([1,2,3], 3, 1)
     a2 = [1.0,2.0,3.0]'
-    a1p, a2p = @inferred(cpaddedviews(0, a1, a2))
+    a1p, a2p = @inferred(sym_paddedviews(0, a1, a2))
 
     @test a1p == OffsetArray([0 1 0; 0 2 0; 0 3 0], (1:3, 0:2))
     @test a1p[CartesianIndices(a1)] == a1
@@ -143,7 +143,7 @@ end
     @test axes(a2p) === (0:2, 1:3)
 
     a3 = OffsetArray([1.0,2.0,3.0]', (0,-1))
-    a1p, a3p = @inferred(cpaddedviews(0, a1, a3))
+    a1p, a3p = @inferred(sym_paddedviews(0, a1, a3))
 
     @test a1p == OffsetArray([0 1 0; 0 2 0; 0 3 0], 1:3, 0:2)
     @test a1p[CartesianIndices(a1)] == a1
@@ -154,7 +154,7 @@ end
     @test axes(a1p) == (1:3, 0:2)
     @test axes(a3p) == (0:2, 0:2)
 
-    @test @inferred(cpaddedviews(3)) == ()
+    @test @inferred(sym_paddedviews(3)) == ()
 end
 
 @testset "showarg" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,9 @@ end
     a2 = [1.0,2.0]'
     a1p, a2p = @inferred(paddedviews(0, a1, a2))
     @test a1p == [1 0; 2 0]
+    @test a1p[CartesianIndices(a1)] == a1
     @test a2p == [1.0 2.0; 0.0 0.0]
+    @test a2p[CartesianIndices(a2)] == a2
     @test eltype(a1p) == Int
     @test eltype(a2p) == Float64
     @test axes(a1p) === axes(a2p) === (Base.OneTo(2), Base.OneTo(2))
@@ -100,7 +102,9 @@ end
     a3 = OffsetArray([1.0,2.0]', (0,-1))
     a1p, a3p = @inferred(paddedviews(0, a1, a3))
     @test a1p == OffsetArray([0 1; 0 2], 1:2, 0:1)
+    @test a1p[CartesianIndices(a1)] == a1
     @test a3p == OffsetArray([1.0 2.0; 0.0 0.0], 1:2, 0:1)
+    @test a3p[CartesianIndices(a3)] == a3
     @test eltype(a1p) == Int
     @test eltype(a3p) == Float64
     @test axes(a1p) === axes(a3p) === (1:2, 0:1)
@@ -110,6 +114,35 @@ end
     # But a zero-dimensional input should not trigger that error
     a = reshape([5])
     @test paddedviews(-1, a) == (a,)
+end
+
+@testset "cpaddedviews" begin
+    a1 = reshape([1,2,3], 3, 1)
+    a2 = [1.0,2.0,3.0]'
+    a1p, a2p = @inferred(cpaddedviews(0, a1, a2))
+
+    @test a1p == OffsetArray([0 1 0; 0 2 0; 0 3 0], (1:3, 0:2))
+    @test a1p[CartesianIndices(a1)] == a1
+    @test a2p == OffsetArray([0.0 0.0 0.0; 1.0 2.0 3.0; 0.0 0.0 0.0], (0:2, 1:3))
+    @test a2p[CartesianIndices(a2)] == a2
+    @test eltype(a1p) == Int
+    @test eltype(a2p) == Float64
+    @test axes(a1p) === (1:3, 0:2)
+    @test axes(a2p) === (0:2, 1:3)
+
+    a3 = OffsetArray([1.0,2.0,3.0]', (0,-1))
+    a1p, a3p = @inferred(cpaddedviews(0, a1, a3))
+
+    @test a1p == OffsetArray([0 1 0; 0 2 0; 0 3 0], 1:3, 0:2)
+    @test a1p[CartesianIndices(a1)] == a1
+    @test a3p == OffsetArray([0.0 0.0 0.0; 1.0 2.0 3.0; 0.0 0.0 0.0], 0:2, 0:2)
+    @test a3p[CartesianIndices(a3)] == a3
+    @test eltype(a1p) == Int
+    @test eltype(a3p) == Float64
+    @test axes(a1p) == (1:3, 0:2)
+    @test axes(a3p) == (0:2, 0:2)
+
+    @test @inferred(cpaddedviews(3)) == ()
 end
 
 @testset "showarg" begin


### PR DESCRIPTION
A centered version of `paddedviews` could be quite convenient in some cases (e.g., compare two images)

~The benchmark says it's 10x slower than `paddedviews` but I failed to make it faster... @timholy can you take a look at it?~

~Edit: it's now 2x slower but I think it's accepted since `cpaddedviews` does more computation.~

Edit: the performance is almost the same now :tada:

```
julia> @btime cpaddedviews(-1, $a1, $a2);
  24.284 ns (3 allocations: 160 bytes)

julia> @btime paddedviews(-1, $a1, $a2);
  22.391 ns (3 allocations: 128 bytes)
```

Preview:

```julia
img1 = ARGB.(testimage("lena"))
img2 = ARGB.(testimage("camera"))

reduce(cpaddedviews(AGray(0, 0), img1, img2)) do x, y
    x = OffsetArray(x, 1 .- first.(axes(x)))
    y = OffsetArray(y, 1 .- first.(axes(y)))
    cat(x, y; dims=1)
end
```

`paddedviews`

![image](https://user-images.githubusercontent.com/8684355/75867676-ec62bb00-5e41-11ea-995a-c530519f4c39.png)

`cpaddedviews`

![image](https://user-images.githubusercontent.com/8684355/75867709-f4baf600-5e41-11ea-8d13-a028076f36e0.png)


