### PR TITLE
promote fillvalue type if it is Colorant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,16 @@ version = "0.5.3"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 OffsetArrays = "0.10, 0.11, 1"
+Requires = "0.5, 1"
 julia = "0.7, 1"
 
 [extras]
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["ImageCore", "Test"]

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -1,6 +1,7 @@
 module PaddedViews
 using Base: OneTo, tail
 using OffsetArrays
+using Requires
 
 export PaddedView, paddedviews, sym_paddedviews
 
@@ -84,16 +85,23 @@ struct PaddedView{T,N,I,A} <: AbstractArray{T,N}
     end
 end
 
-function PaddedView(fillvalue, data::AbstractArray{T,N}, indices) where {T,N}
-    _T = fillvalue isa Union{Missing, Nothing} ? Union{typeof(fillvalue), T} : T
-    PaddedView{_T,N,typeof(indices),typeof(data)}(convert(_T, fillvalue), data, indices)
+function PaddedView(fillvalue::FT,
+                    data::AbstractArray{T,N},
+                    indices) where {FT,T,N}
+    _FT = filltype(FT, T)
+    PaddedView{_FT,N,typeof(indices),typeof(data)}(convert(_FT, fillvalue), data, indices)
 end
 
-function PaddedView(fillvalue, data::AbstractArray{T,N}, sz::Tuple{Integer,Vararg{Integer}}) where {T,N}
+function PaddedView(fillvalue::FT,
+                    data::AbstractArray{T,N},
+                    sz::Tuple{Integer,Vararg{Integer}}) where {FT,T,N}
     inds = map(OneTo, sz)
-    _T = fillvalue isa Union{Missing, Nothing} ? Union{typeof(fillvalue), T} : T
-    PaddedView{_T,N,typeof(inds),typeof(data)}(convert(_T, fillvalue), data, inds)
+    _FT = filltype(FT, T)
+    PaddedView{_FT,N,typeof(inds),typeof(data)}(convert(_FT, fillvalue), data, inds)
 end
+
+filltype(::Type, ::Type{T}) where T = T
+filltype(::Type{FT}, ::Type{T}) where {FT<:Union{Nothing, Missing}, T} = Union{FT, T}
 
 # This method eliminates an ambiguity between the two below it
 function PaddedView(fillvalue,
@@ -132,7 +140,7 @@ Base.parent(A::PaddedView) = A.data
 @inline function Base.getindex(A::PaddedView{T,N}, i::Vararg{Int,N}) where {T,N}
     @boundscheck checkbounds(A, i...)
     if Base.checkbounds(Bool, A.data, i...)
-        return A.data[i...]
+        return convert(T, A.data[i...])
     end
     return A.fillvalue
 end
@@ -272,6 +280,27 @@ function Base.showarg(io::IO, A::PaddedView, toplevel)
     print(io, ", (", join(A.indices, ", "))
     print(io, ndims(A) == 1 ? ",))" : "))")
     toplevel && print(io, " with eltype ", eltype(A))
+end
+
+function __init__()
+    @require ColorTypes="3da002f7-5984-5a60-b8a6-cbb66c0b333f" begin
+        function filltype(::Type{FC}, ::Type{C}) where {FC<:ColorTypes.Colorant,
+                                                        C<:ColorTypes.Colorant}
+            # rand(RGB, 4, 4) has eltype RGB{Any} but it isn't a concrete type
+            # although the consensus[1] is to not make a concrete eltype, this op is needed to make a
+            # type-stable colorant construction in _filltype without error; there's no RGB{Any} thing
+            # [1]: https://github.com/JuliaLang/julia/pull/34948
+            T = eltype(C) === Any ? eltype(FC) : eltype(C)
+            _filltype(FC, ColorTypes.base_colorant_type(C){T})
+        end
+        _filltype(::Type{<:ColorTypes.Colorant}, ::Type{C}) where {C<:ColorTypes.Colorant} = C
+        _filltype(::Type{FC}, ::Type{C}) where {FC<:ColorTypes.Color3, C<:ColorTypes.AbstractGray} =
+            ColorTypes.base_colorant_type(FC){promote_type(eltype(FC), eltype(C))}
+        _filltype(::Type{FC}, ::Type{C}) where {FC<:ColorTypes.TransparentColor, C<:ColorTypes.AbstractGray} =
+            ColorTypes.alphacolor(FC){promote_type(eltype(FC), eltype(C))}
+        _filltype(::Type{FC}, ::Type{C}) where {FC<:ColorTypes.TransparentColor, C<:ColorTypes.Color3} =
+            ColorTypes.alphacolor(C){promote_type(eltype(FC), eltype(C))}
+    end
 end
 
 end # module


### PR DESCRIPTION
It's weird that regions are not filled by `fillvalue` in following cases

```julia
# in master: filled by Gray(RGB(1.,0.,0.))
# in this PR: filled by RGB(1.,0.,0.)
PaddedView(RGB(1.,0.,0.), fill(Gray(0.), 2, 2), (-1:4, -1:4))
```

Cases such as transparent colors as `fillvalue` are also handled.

The only issue I see is the loading time:

* this branch without ColorTypes loaded: 0.26s
* this branch with ColorTypes loaded: 0.48s
* master: **0.07s**

If the loading time is unacceptable, the only place I can think of is `ImageShow`/`ImageCore` -- but that would be type piracy IIUC.

This PR serves https://github.com/JuliaImages/ImageShow.jl/pull/19 to make `mosaicview` a really useful `imshow` alternative