### PR TITLE
introduce a non-exported filltype

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PaddedViews"
 uuid = "5432bcbf-9aad-5242-b902-cca2824c8663"
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using OffsetArrays
 using Test
 ambs = detect_ambiguities(Base, Core)  # in case these have ambiguities of their own
 using PaddedViews
+using PaddedViews: filltype
 @testset "ambiguities" begin
     @test isempty(setdiff(detect_ambiguities(PaddedViews, Base, Core), ambs))
 end
@@ -197,6 +198,13 @@ end
 end
 
 @testset "nothing/missing" begin
+    for (FT, T) in ((Missing, Float32),
+                    (Nothing, Float32))
+        @test @inferred(filltype(FT, T)) === Union{FT, T}
+        @test @inferred(filltype(T, Union{FT, T})) === Union{FT, T}
+        @test @inferred(filltype(FT, Union{FT, T})) === Union{FT, T}
+    end
+
     for (T, v) in ((Missing, missing),
                  (Nothing, nothing))
         A = reshape(1:9, 3, 3)


### PR DESCRIPTION
This continues #24 by make filltype conversion extensible to other
packages, e.g., it makes lifting filltype for `Colorants` possible
in other packages.

This is a rework of #25 by breaking it into two PRs