### PR TITLE
allow users to explicity specify filltype

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PaddedViews"
 uuid = "5432bcbf-9aad-5242-b902-cca2824c8663"
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -9,6 +9,7 @@ export PaddedView, paddedviews, sym_paddedviews
     datapadded = PaddedView(fillvalue, data, padded_axes, data_axes)
     datapadded = PaddedView(fillvalue, data, sz)
     datapadded = PaddedView(fillvalue, data, sz, first_datum)
+    datapadded = PaddedView{T}(args...)
 
 Create a padded version of the array `data`, where any elements within
 the span of `padded_axes` not assigned in `data` will have value
@@ -29,6 +30,11 @@ One may optionally specify the location of the `[1, 1, ...]` element of `data` w
 `first_datum`.
 Specifically, `datapadded[first_datum...]` corresponds to `data[1, 1, ...]`.
 `first_datum` defaults to all-1s.
+
+The view eltype `T` is optional. If not specified, then in most cases, `T` is inferred to be
+`eltype(data)`. In cases when `fillvalue` can't be converted to `eltype(data)`, `T` will be
+promoted the one that does. For example, when `fillvalue == nothing` and `eltype(data) == Float32`,
+the inferred eltype `T` will be `Union{Nothing, Float32}`.
 
 # Example
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,7 @@ end
     A32 = @inferred(PaddedView{Float32}(0.0, a, (Base.OneTo(4), Base.OneTo(5))))
     @test eltype(A32) == Float32
     @test A32 == A
+    @test A32[1, 1] === 1.0f0
 
     A = @inferred(PaddedView(0.0, a, (0:4, -1:5)))
     @test eltype(A) == Int
@@ -51,6 +52,7 @@ end
     A32 = @inferred(PaddedView{Float32}(0.0, a, (0:4, -1:5)))
     @test eltype(A32) == Float32
     @test A32 == A
+    @test A32[1, 1] === 1.0f0
 
     A = @inferred(PaddedView(0.0, a, (Base.OneTo(5), Base.OneTo(5)), (2:4, 2:4)))
     @test A == [0 0 0 0 0;
@@ -61,11 +63,13 @@ end
     A32 = @inferred(PaddedView{Float32}(0.0, a, (Base.OneTo(5), Base.OneTo(5)), (2:4, 2:4)))
     @test eltype(A32) == Float32
     @test A32 == A
+    @test A32[2, 2] === 1.0f0
 
     @test A == @inferred(PaddedView(0.0, a, (5, 5), (2, 2)))
     A32 = @inferred(PaddedView{Float32}(0.0, a, (5, 5), (2, 2)))
     @test eltype(A32) == Float32
     @test A32 == A
+    @test A32[2, 2] === 1.0f0
     
     B = @inferred(PaddedView(0.0, OffsetArray(a, (2:4, 2:4)), (Base.OneTo(5), Base.OneTo(5))))
     @test B == A

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,9 @@ end
                 2 5 8 0 0;
                 3 6 9 0 0;
                 0 0 0 0 0]
+    A32 = @inferred(PaddedView{Float32}(0.0, a, (Base.OneTo(4), Base.OneTo(5))))
+    @test eltype(A32) == Float32
+    @test A32 == A
 
     A = @inferred(PaddedView(0.0, a, (0:4, -1:5)))
     @test eltype(A) == Int
@@ -45,6 +48,9 @@ end
                             0 0 2 5 8 0 0;
                             0 0 3 6 9 0 0;
                             0 0 0 0 0 0 0], 0:4, -1:5)
+    A32 = @inferred(PaddedView{Float32}(0.0, a, (0:4, -1:5)))
+    @test eltype(A32) == Float32
+    @test A32 == A
 
     A = @inferred(PaddedView(0.0, a, (Base.OneTo(5), Base.OneTo(5)), (2:4, 2:4)))
     @test A == [0 0 0 0 0;
@@ -52,7 +58,15 @@ end
                 0 2 5 8 0;
                 0 3 6 9 0;
                 0 0 0 0 0]
+    A32 = @inferred(PaddedView{Float32}(0.0, a, (Base.OneTo(5), Base.OneTo(5)), (2:4, 2:4)))
+    @test eltype(A32) == Float32
+    @test A32 == A
+
     @test A == @inferred(PaddedView(0.0, a, (5, 5), (2, 2)))
+    A32 = @inferred(PaddedView{Float32}(0.0, a, (5, 5), (2, 2)))
+    @test eltype(A32) == Float32
+    @test A32 == A
+    
     B = @inferred(PaddedView(0.0, OffsetArray(a, (2:4, 2:4)), (Base.OneTo(5), Base.OneTo(5))))
     @test B == A
 


### PR DESCRIPTION
Continues #25 and #26 

Users now can control the eltype of PaddedView using `PaddedView{T}(fillvalue, data, ...)`. If `T` is not provided, it infers the appropriate type from `fillvalue` and `data` using `filltype`, which is the previous behavior.

However, it's expected that the benchmark is not optimistic if we're abusing the usage:

`UInt -> Int`:

```julia
julia> A = UInt.(repeat(collect(1:512), 1, 512));
julia> B_Int = PaddedView{Int}(0.0, A, (-2:515, -2:515));
julia> B_UInt = PaddedView{UInt}(0.0, A, (-2:515, -2:515));

julia> @btime collect(A);
  90.161 μs (2 allocations: 2.00 MiB)

julia> @btime collect($B_UInt); # baseline # PaddedViews 0.5.3: 240.691 μs
  241.527 μs (2 allocations: 2.05 MiB)

julia> @btime collect($B_Int); # slower
  291.259 μs (2 allocations: 2.05 MiB)
```

`Int -> UInt`:

```julia
julia> A = Int.(repeat(collect(1:512), 1, 512));
julia> B_Int = PaddedView{Int}(0.0, A, (-2:515, -2:515));
julia> B_UInt = PaddedView{UInt}(0.0, A, (-2:515, -2:515));

julia> @btime collect(A);
  87.306 μs (2 allocations: 2.00 MiB)

julia> @btime collect($B_Int); # baseline # PaddedViews 0.5.3: 165.079 μs
  172.315 μs (2 allocations: 2.05 MiB)

julia> @btime collect($B_UInt); # slower
  297.698 μs (2 allocations: 2.05 MiB)
```


- [x] Needs to update docs

P.S., Is there anything we can do inside this package to reduce the timing difference between `collect(A)` and `collect(B)`?