### PR TITLE
Make doctests agnostic to system word size

### DIFF
--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -36,20 +36,20 @@ Specifically, `datapadded[first_datum...]` corresponds to `data[1, 1, ...]`.
 julia> using PaddedViews
 
 julia> a = collect(reshape(1:9, 3, 3))
-3×3 Array{Int64,2}:
+3×3 Array{$Int,2}:
  1  4  7
  2  5  8
  3  6  9
 
 julia> PaddedView(-1, a, (4, 5))
-4×5 PaddedView(-1, ::Array{Int64,2}, (Base.OneTo(4), Base.OneTo(5))) with eltype Int64:
+4×5 PaddedView(-1, ::Array{$Int,2}, (Base.OneTo(4), Base.OneTo(5))) with eltype $Int:
   1   4   7  -1  -1
   2   5   8  -1  -1
   3   6   9  -1  -1
  -1  -1  -1  -1  -1
 
 julia> PaddedView(-1, a, (1:5,1:5), (2:4,2:4))
-5×5 PaddedView(-1, OffsetArray(::Array{Int64,2}, 2:4, 2:4), (1:5, 1:5)) with eltype Int64 with indices 1:5×1:5:
+5×5 PaddedView(-1, OffsetArray(::Array{$Int,2}, 2:4, 2:4), (1:5, 1:5)) with eltype $Int with indices 1:5×1:5:
  -1  -1  -1  -1  -1
  -1   1   4   7  -1
  -1   2   5   8  -1
@@ -57,7 +57,7 @@ julia> PaddedView(-1, a, (1:5,1:5), (2:4,2:4))
  -1  -1  -1  -1  -1
 
 julia> PaddedView(-1, a, (0:4, 0:4))
-5×5 PaddedView(-1, ::Array{Int64,2}, (0:4, 0:4)) with eltype Int64 with indices 0:4×0:4:
+5×5 PaddedView(-1, ::Array{$Int,2}, (0:4, 0:4)) with eltype $Int with indices 0:4×0:4:
  -1  -1  -1  -1  -1
  -1   1   4   7  -1
  -1   2   5   8  -1
@@ -65,7 +65,7 @@ julia> PaddedView(-1, a, (0:4, 0:4))
  -1  -1  -1  -1  -1
 
 julia> PaddedView(-1, a, (5,5), (2,2))
-5×5 PaddedView(-1, OffsetArray(::Array{Int64,2}, 2:4, 2:4), (Base.OneTo(5), Base.OneTo(5))) with eltype Int64:
+5×5 PaddedView(-1, OffsetArray(::Array{$Int,2}, 2:4, 2:4), (Base.OneTo(5), Base.OneTo(5))) with eltype $Int:
  -1  -1  -1  -1  -1
  -1   1   4   7  -1
  -1   2   5   8  -1
@@ -102,7 +102,7 @@ function PaddedView(fillvalue::FT,
 end
 
 # No need to export this
-# 
+#
 # **Regardless of accuracy**, when `data` cannot represent the exact meaning of fillvalue
 # object, the type of `fillvalue` should be lifted to a common type.
 # Examples of this are: `Nothing`, `Missing`, `ColorTypes.Colorant`
@@ -174,31 +174,31 @@ that `Ap[CartesianIndices(A)] == A`.
 julia> using PaddedViews
 
 julia> a1 = reshape([1, 2, 3], 3, 1)
-3×1 Array{Int64,2}:
+3×1 Array{$Int,2}:
  1
  2
  3
 
 julia> a2 = [4 5 6]
-1×3 Array{Int64,2}:
+1×3 Array{$Int,2}:
  4  5  6
 
 julia> a1p, a2p = paddedviews(-1, a1, a2);
 
 julia> a1p
-3×3 PaddedView(-1, ::Array{Int64,2}, (Base.OneTo(3), Base.OneTo(3))) with eltype Int64:
+3×3 PaddedView(-1, ::Array{$Int,2}, (Base.OneTo(3), Base.OneTo(3))) with eltype $Int:
  1  -1  -1
  2  -1  -1
  3  -1  -1
 
 julia> a2p
-3×3 PaddedView(-1, ::Array{Int64,2}, (Base.OneTo(3), Base.OneTo(3))) with eltype Int64:
+3×3 PaddedView(-1, ::Array{$Int,2}, (Base.OneTo(3), Base.OneTo(3))) with eltype $Int:
   4   5   6
  -1  -1  -1
  -1  -1  -1
 
 julia> a1p[CartesianIndices(a1)]
-3×1 Array{Int64,2}:
+3×1 Array{$Int,2}:
  1
  2
  3
@@ -244,31 +244,31 @@ that `Ap[CartesianIndices(A)] == A`.
 julia> using PaddedViews
 
 julia> a1 = reshape([1, 2, 3], 3, 1)
-3×1 Array{Int64,2}:
+3×1 Array{$Int,2}:
  1
  2
  3
 
 julia> a2 = [4 5 6]
-1×3 Array{Int64,2}:
+1×3 Array{$Int,2}:
  4  5  6
 
 julia> a1p, a2p = sym_paddedviews(-1, a1, a2);
 
 julia> a1p
-3×3 PaddedView(-1, ::Array{Int64,2}, (1:3, 0:2)) with eltype Int64 with indices 1:3×0:2:
+3×3 PaddedView(-1, ::Array{$Int,2}, (1:3, 0:2)) with eltype $Int with indices 1:3×0:2:
  -1  1  -1
  -1  2  -1
  -1  3  -1
 
 julia> a2p
-3×3 PaddedView(-1, ::Array{Int64,2}, (0:2, 1:3)) with eltype Int64 with indices 0:2×1:3:
+3×3 PaddedView(-1, ::Array{$Int,2}, (0:2, 1:3)) with eltype $Int with indices 0:2×1:3:
  -1  -1  -1
   4   5   6
  -1  -1  -1
 
 julia> a1p[CartesianIndices(a1)]
-3×1 Array{Int64,2}:
+3×1 Array{$Int,2}:
  1
  2
  3


### PR DESCRIPTION
I think all our tests run only on 64-bit machines, but this is just in case we change that.