### PR TITLE
Implement efficent methods for `any`/`all`

### DIFF
--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -310,7 +310,8 @@ function Base.showarg(io::IO, A::PaddedView, toplevel)
 end
 
 # The fallbacks work, but this is more efficient
-Base.any(A::PaddedView) = A.fillvalue || any(parent(A))
-Base.all(A::PaddedView) = A.fillvalue && all(parent(A))
+# TODO use use short-circuit evaluation,
+Base.any(f::Function, A::PaddedView) = f(A.fillvalue) | any(f, parent(A))
+Base.all(f::Function, A::PaddedView) = f(A.fillvalue) & all(f, parent(A))
 
 end # module

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -309,4 +309,8 @@ function Base.showarg(io::IO, A::PaddedView, toplevel)
     toplevel && print(io, " with eltype ", eltype(A))
 end
 
+# The fallbacks work, but this is more efficient
+Base.any(A::PaddedView) = A.fillvalue || any(parent(A))
+Base.all(A::PaddedView) = A.fillvalue && all(parent(A))
+
 end # module

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -313,5 +313,10 @@ end
 # TODO use use short-circuit evaluation,
 Base.any(f::Function, A::PaddedView) = f(A.fillvalue) | any(f, parent(A))
 Base.all(f::Function, A::PaddedView) = f(A.fillvalue) & all(f, parent(A))
+if v"0.7" <= VERSION < v"1.1"
+    # ambiguity patch
+    # https://github.com/JuliaLang/julia/pull/30904
+    Base.all(::typeof(isinteger), ::PaddedView{<:Integer}) = true
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,14 +253,29 @@ end
 end
 
 @testset "specializations" begin
-    for (p, v) in ((true, true), (true, false), (false, true), (false, false))
-        a = fill(v, (1, 1))
-        pa = PaddedView(p, a, (1:2, 1:2))
-        mpa = collect(pa)
-
-        # ensure specializations are equivalent to fallbacks
-        for f in (any, all)
-            @test f(pa) == f(mpa)
+    @testset "trivalent logic" begin
+        for (p, v) in Iterators.product(ntuple(_->(true, false, missing), 2)...)
+            a = fill(v, (1, 1))
+            pa = PaddedView(p, a, (1:2, 1:2))
+            mpa = collect(pa)
+            # ensure specializations are equivalent to fallbacks
+            for f in (any, all)
+                @test isequal(f(pa), f(mpa))
+            end
+        end
+    end
+    @testset "with predicates" begin
+        for (p, v) in Iterators.product(ntuple(_->(0, 1), 2)...)
+            a = fill(v, (1, 1))
+            pa = PaddedView(p, a, (1:2, 1:2))
+            mpa = collect(pa)
+            # ensure specializations are equivalent to fallbacks
+            fp = ==(0)
+            for f in (any, all)
+                v1 = f(fp, pa)
+                v2 = f(fp, mpa)
+                @test isequal(v1, v2)
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,3 +251,16 @@ end
         @test Ap[axes(A)...] == A
     end
 end
+
+@testset "specializations" begin
+    for (p, v) in ((true, true), (true, false), (false, true), (false, false))
+        a = fill(v, (1, 1))
+        pa = PaddedView(p, a, (1:2, 1:2))
+        mpa = collect(pa)
+
+        # ensure specializations are equivalent to fallbacks
+        for f in (any, all)
+            @test f(pa) == f(mpa)
+        end
+    end
+end


### PR DESCRIPTION
Relates to issue #31