### PR TITLE
propagate inbounds in getindex

### DIFF
--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -160,7 +160,7 @@ Base.size(A::PaddedView) = map(length, axes(A))
 
 Base.parent(A::PaddedView) = A.data
 
-Base.@propagate_inbounds function Base.getindex(A::PaddedView{T,N}, i::Vararg{Int,N})::T where {T,N}
+Base.@propagate_inbounds function Base.getindex(A::PaddedView{T,N}, i::Vararg{Int,N}) where {T,N}
     @boundscheck checkbounds(A, i...)
     if Base.checkbounds(Bool, A.data, i...)
         return convert(T, A.data[i...])

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -160,7 +160,7 @@ Base.size(A::PaddedView) = map(length, axes(A))
 
 Base.parent(A::PaddedView) = A.data
 
-@inline function Base.getindex(A::PaddedView{T,N}, i::Vararg{Int,N}) where {T,N}
+Base.@propagate_inbounds function Base.getindex(A::PaddedView{T,N}, i::Vararg{Int,N})::T where {T,N}
     @boundscheck checkbounds(A, i...)
     if Base.checkbounds(Bool, A.data, i...)
         return convert(T, A.data[i...])


### PR DESCRIPTION
I'm not that confident about the benchmark result, though. Probably I'm just benchmarking the cached performance here... but I guess it still explains some differences.

```julia
julia> A = reshape(collect(1:6), 2, 3);

julia> Ap = PaddedView(0, A, (0:4, 0:4));

julia> @btime getindex($A, 1, 1);
  1.421 ns (0 allocations: 0 bytes)

julia> @btime getindex($Ap, 1, 1);
  1.975 ns (0 allocations: 0 bytes)

julia> @btime getindex($Ap, 0, 0);
  1.696 ns (0 allocations: 0 bytes)

julia> @btime @inbounds getindex($Ap, 1, 1);
  1.420 ns (0 allocations: 0 bytes) # PR
  1.696 ns (0 allocations: 0 bytes) # master

julia> @btime @inbounds getindex($Ap, 0, 0);
  1.421 ns (0 allocations: 0 bytes) # PR
  1.703 ns (0 allocations: 0 bytes) # master
```

Unsure the cause here, adding `T` notation gives a better performance for `missing` case:

```julia
julia> A = reshape(collect(1:6), 2, 3);

julia> Ap = PaddedView(missing, A, (0:4, 0:4));

julia> @btime getindex($Ap, 1, 1);
  2.462 ns (0 allocations: 0 bytes) # PR
  3.009 ns (0 allocations: 0 bytes) # master

julia> @btime getindex($Ap, 0, 0);
  2.196 ns (0 allocations: 0 bytes) # PR
  2.193 ns (0 allocations: 0 bytes) # master

julia> @btime @inbounds getindex($Ap, 1, 1);
  1.697 ns (0 allocations: 0 bytes) # PR
  2.193 ns (0 allocations: 0 bytes) # master

julia> @btime @inbounds getindex($Ap, 0, 0);
  1.697 ns (0 allocations: 0 bytes) # PR
  1.652 ns (0 allocations: 0 bytes) # master
```