### PR TITLE
delay setindex! inbounds check indexlinear

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ notifications:
   email: false
 codecov: true
 # uncomment the following lines to override the default test script
-#script:
-#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("PaddedViews"); Pkg.test("PaddedViews"; coverage=true)'
+# Pkg.test set `bounds-check=yes`, which skips the inbounds behavior test
+# Here we add one more process to test inbounds behavior
+script:
+ - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+ - julia -e 'Pkg.clone(pwd()); Pkg.build("PaddedViews"); Pkg.test("PaddedViews"; coverage=true)'
+ - julia --project=. test/runtests.jl

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -188,7 +188,7 @@ end
 
 Base.@propagate_inbounds function Base.setindex!(A::PaddedView, v, i::Int)
     # delay the boundscheck in the IndexCartesian version and not set @inbounds meta here
-    setindex!(A, v, Base._to_subscript_indices(A, i...)...)
+    setindex!(A, v, Base._to_subscript_indices(A, i)...)
 end
 
 """

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -186,6 +186,11 @@ Base.@propagate_inbounds function Base.setindex!(A::PaddedView{T, N}, v, i::Vara
     return A
 end
 
+Base.@propagate_inbounds function Base.setindex!(A::PaddedView, v, i::Int)
+    # delay the boundscheck in the IndexCartesian version and not set @inbounds meta here
+    setindex!(A, v, Base._to_subscript_indices(A, i...)...)
+end
+
 """
     Aspad = paddedviews(fillvalue, A1, A2, ....)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -310,6 +310,9 @@ end
         Ap[1, 1] = 10
         @test Ap[7] == Ap[1, 1] == 10
 
+        err = ArgumentError("PaddedViews do not support (re)setting the padding value. Consider making a copy of the array first.")
+        @test_throws err setindex!(Ap, 10, 1)
+
         A = reshape(collect(1:6), 2, 3)
         Ap = PaddedView(missing, A, (3:4, 4:6))
         @test axes(Ap) == (3:4, 4:6)


### PR DESCRIPTION
This is needed to bypass the `@inbounds` check in the [fallback implementation](https://github.com/JuliaLang/julia/blob/c24a93253db45131983c665373d17759f9d4b758/base/abstractarray.jl#L1249-L1254), and use our own bounds checking, otherwise, `setindex!` for indexlinear will always be set with `@inbounds` mode.

I'm not very sure if this is the right fix, perhaps I've used `@boundscheck` wrongly https://github.com/JuliaArrays/PaddedViews.jl/blob/ff689b1f5d41545f3decf1f00b94c5ad7b1d5ac8/src/PaddedViews.jl#L172-L187