### PR TITLE
Make sure that axes are their own axes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PaddedViews"
 uuid = "5432bcbf-9aad-5242-b902-cca2824c8663"
-version = "0.5.11"
+version = "0.5.12"
 
 [deps]
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"

--- a/src/PaddedViews.jl
+++ b/src/PaddedViews.jl
@@ -1,7 +1,12 @@
 module PaddedViews
-using Base: OneTo, tail, IdentityUnitRange
+using Base: OneTo, tail
 using OffsetArrays
 using OffsetArrays: no_offset_view
+@static if !isdefined(Base, :IdentityUnitRange)
+    const IdentityUnitRange = Base.Slice
+else
+    using Base: IdentityUnitRange
+end
 
 export PaddedView, paddedviews, sym_paddedviews
 
@@ -104,17 +109,13 @@ function PaddedView(fillvalue::FT,
     PaddedView{filltype(FT, T)}(fillvalue, data, padded_inds, data_inds)
 end
 
-function _to_axes(rs::Tuple{AbstractUnitRange,Vararg{AbstractUnitRange}})
-    (_to_axis(first(rs)), _to_axes(rs[2:end])...)
-end
-_to_axes(::Tuple{}) = ()
 _to_axis(x::Union{OneTo, IdentityUnitRange}) = x
 _to_axis(r::AbstractUnitRange) = IdentityUnitRange(r)
 
 function PaddedView{FT}(fillvalue,
                         data::AbstractArray{T,N},
                         indices) where {FT,T,N}
-    indsoffset = _to_axes(indices)
+    indsoffset = map(_to_axis, indices)
     PaddedView{FT,N,typeof(indsoffset),typeof(data)}(convert(FT, fillvalue), data, indsoffset)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using OffsetArrays
 using Test
 ambs = detect_ambiguities(Base, Core)  # in case these have ambiguities of their own
 using PaddedViews
-using PaddedViews: filltype
+using PaddedViews: filltype, IdentityUnitRange
 @testset "ambiguities" begin
     @test isempty(setdiff(detect_ambiguities(PaddedViews, Base, Core), ambs))
 end
@@ -49,8 +49,8 @@ end
     @test eltype(A) == Int
     @test ndims(A) == 2
     @test size(A) == (5, 7)
-    @test @inferred(axes(A)) === map(Base.IdentityUnitRange, (0:4, -1:5))
-    @test @inferred(axes(A, 3)) == Base.IdentityUnitRange(1:1)
+    @test @inferred(axes(A)) === map(IdentityUnitRange, (0:4, -1:5))
+    @test @inferred(axes(A, 3)) == IdentityUnitRange(1:1)
     @test A == OffsetArray([0 0 0 0 0 0 0;
                             0 0 1 4 7 0 0;
                             0 0 2 5 8 0 0;
@@ -154,7 +154,7 @@ end
     @test a3p[CartesianIndices(a3)] == a3
     @test eltype(a1p) == Int
     @test eltype(a3p) == Float64
-    @test axes(a1p) === axes(a3p) === map(Base.IdentityUnitRange, (1:2, 0:1))
+    @test axes(a1p) === axes(a3p) === map(IdentityUnitRange, (1:2, 0:1))
 
     @test @inferred(paddedviews(3)) == ()
     @test_throws ErrorException PaddedViews.outerinds()
@@ -224,7 +224,7 @@ end
     @test a2p[CartesianIndices(a2)] == a2
     @test eltype(a1p) == Int
     @test eltype(a2p) == Float64
-    @test axes(a1p) === axes(a2p) === map(Base.IdentityUnitRange, (1:2, 1:2))
+    @test axes(a1p) === axes(a2p) === map(IdentityUnitRange, (1:2, 1:2))
 
     a1 = reshape([1,2,3], 3, 1)
     a2 = [1.0,2.0,3.0]'
@@ -238,8 +238,8 @@ end
     @test a2p[CartesianIndices(a2)] == a2
     @test eltype(a1p) == Int
     @test eltype(a2p) == Float64
-    @test axes(a1p) === map(Base.IdentityUnitRange, (1:3, 0:2))
-    @test axes(a2p) === map(Base.IdentityUnitRange, (0:2, 1:3))
+    @test axes(a1p) === map(IdentityUnitRange, (1:3, 0:2))
+    @test axes(a2p) === map(IdentityUnitRange, (0:2, 1:3))
 
     a1p, a2p, a3p = @inferred(sym_paddedviews(0, a1, a2, a1))
     @test a1p == a3p == OffsetArray([0 1 0; 0 2 0; 0 3 0], (1:3, 0:2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,8 +49,8 @@ end
     @test eltype(A) == Int
     @test ndims(A) == 2
     @test size(A) == (5, 7)
-    @test @inferred(axes(A)) === (0:4, -1:5)
-    @test @inferred(axes(A, 3)) === 1:1
+    @test @inferred(axes(A)) === map(Base.IdentityUnitRange, (0:4, -1:5))
+    @test @inferred(axes(A, 3)) == Base.IdentityUnitRange(1:1)
     @test A == OffsetArray([0 0 0 0 0 0 0;
                             0 0 1 4 7 0 0;
                             0 0 2 5 8 0 0;
@@ -111,6 +111,11 @@ end
         pv = @inferred PaddedView(-1, oa, (3, 2), (2, 0))
         @test pv[1:3, 1:2] == [1 3; 2 4; -1 -1]
     end
+
+    # test for offset axes: the axes should be their own axes
+    a = [1,2,3]
+    P = PaddedView(-1, a, (0:3,))
+    @test first(P) == P[first(LinearIndices(P))]
 end
 
 @testset "paddedviews" begin
@@ -149,7 +154,7 @@ end
     @test a3p[CartesianIndices(a3)] == a3
     @test eltype(a1p) == Int
     @test eltype(a3p) == Float64
-    @test axes(a1p) === axes(a3p) === (1:2, 0:1)
+    @test axes(a1p) === axes(a3p) === map(Base.IdentityUnitRange, (1:2, 0:1))
 
     @test @inferred(paddedviews(3)) == ()
     @test_throws ErrorException PaddedViews.outerinds()
@@ -219,7 +224,7 @@ end
     @test a2p[CartesianIndices(a2)] == a2
     @test eltype(a1p) == Int
     @test eltype(a2p) == Float64
-    @test axes(a1p) === axes(a2p) === (1:2, 1:2)
+    @test axes(a1p) === axes(a2p) === map(Base.IdentityUnitRange, (1:2, 1:2))
 
     a1 = reshape([1,2,3], 3, 1)
     a2 = [1.0,2.0,3.0]'
@@ -233,8 +238,8 @@ end
     @test a2p[CartesianIndices(a2)] == a2
     @test eltype(a1p) == Int
     @test eltype(a2p) == Float64
-    @test axes(a1p) === (1:3, 0:2)
-    @test axes(a2p) === (0:2, 1:3)
+    @test axes(a1p) === map(Base.IdentityUnitRange, (1:3, 0:2))
+    @test axes(a2p) === map(Base.IdentityUnitRange, (0:2, 1:3))
 
     a1p, a2p, a3p = @inferred(sym_paddedviews(0, a1, a2, a1))
     @test a1p == a3p == OffsetArray([0 1 0; 0 2 0; 0 3 0], (1:3, 0:2))


### PR DESCRIPTION
This is required for consistency, and this resolves the following issue on master:
```julia
julia> a = [1,2,3]
3-element Vector{Int64}:
 1
 2
 3

julia> P = PaddedView(-1, a, (0:3,))
4-element PaddedView(-1, ::Vector{Int64}, (0:3,)) with eltype Int64 with indices 0:3:
 -1
  1
  2
  3

julia> eachindex(P) == LinearIndices(P)
false

julia> first(P) == P[first(LinearIndices(P))]
false
```
After this,
```julia
julia> eachindex(P) == LinearIndices(P)
true

julia> first(P) == P[first(LinearIndices(P))]
true

julia> axes(P)
(Base.IdentityUnitRange(0:3),)
```